### PR TITLE
Fix buffer overflow problem in plugin APIs

### DIFF
--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -1172,7 +1172,11 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 				{
 					BufferID id = _mainDocTab.getBufferByIndex(i);
 					Buffer * buf = MainFileManager.getBufferByID(id);
-					lstrcpy(fileNames[j++], buf->getFullPathName());
+					LPWSTR res = lstrcpyW(fileNames[j++], buf->getFullPathName());
+					if (!res)
+					{
+						throw std::exception("Exception: NPPM_GETOPENFILENAMES/NPPM_GETOPENFILENAMESPRIMARY - The buffer you provide may not be large enough to contain the path you want to copy.");
+					}
 				}
 			}
 
@@ -1182,7 +1186,11 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPa
 				{
 					BufferID id = _subDocTab.getBufferByIndex(i);
 					Buffer * buf = MainFileManager.getBufferByID(id);
-					lstrcpy(fileNames[j++], buf->getFullPathName());
+					LPWSTR res = lstrcpyW(fileNames[j++], buf->getFullPathName());
+					if (!res)
+					{
+						throw std::exception("Exception: NPPM_GETOPENFILENAMES/NPPM_GETOPENFILENAMESSECOND - The buffer you provide may not be large enough to contain the path you want to copy.");
+					}
 				}
 			}
 			return j;


### PR DESCRIPTION
Concerning message: NPPM_GETOPENFILENAMES, NPPM_GETOPENFILENAMESPRIMARY & NPPM_GETOPENFILENAMESECOND
Ref: https://github.com/notepad-plus-plus/notepad-plus-plus/issues/15997#issuecomment-2569862393

Fix #15997